### PR TITLE
support spaces in command-line args

### DIFF
--- a/common.c
+++ b/common.c
@@ -946,8 +946,7 @@ void COM_InitArgv (int argc, const char **argv)
 		// necessary.
 		while ((n < (CMDLINE_LENGTH - 1)) && arg[i])
 		{
-			if ((arg[i] == '"') ||
-				 ((!has_whitespace) && (arg[i] == '\\')))
+			if ((arg[i] == '"') || ((!has_whitespace) && (arg[i] == '\\')))
 			{
 				com_cmdline[n++] = '\\';
 				if (n >= CMDLINE_LENGTH)

--- a/common.c
+++ b/common.c
@@ -916,57 +916,76 @@ COM_InitArgv
 */
 static char	*whitespace = " \t";
 
-void COM_InitArgv (int argc, const char **argv)
+void COM_InitArgv (int argc, const char **argv, const char *cmdline)
 {
+	int		i;
 	qboolean	safe;
-	int		i, j, n;
-	qboolean	has_whitespace;
 
-// reconstitute the command line for the cmdline externally visible cvar
-	n = 0;
-
-	for (j=0 ; j<MAX_NUM_ARGVS && j<argc ; j++)
+	// If we have the original command line available, copy that to com_cmdline.
+	// Otherwise reconstitute it from argc/argv, using bash-like quoting
+	// conventions for quotes and backslashes. (These conventions are not
+	// accurate for Windows builds... which should pass in cmdline instead.)
+	if (cmdline != NULL)
 	{
-		char *arg = argv[j];
-		i = 0;
-
-		// See if we need to quote the arg.
-		if (strcspn(arg, whitespace) == strlen(arg))
-		{
-			has_whitespace = false;
-		}
-		else
-		{
-			has_whitespace = true;
-			if (n < (CMDLINE_LENGTH - 1))
-				com_cmdline[n++] = '"';
-		}
-
-		// Copy in the chars of the arg. Backslash any quote or backslash chars as
-		// necessary.
-		while ((n < (CMDLINE_LENGTH - 1)) && arg[i])
-		{
-			if ((arg[i] == '"') || ((!has_whitespace) && (arg[i] == '\\')))
-			{
-				com_cmdline[n++] = '\\';
-				if (n >= CMDLINE_LENGTH)
-					break;
-			}
-			com_cmdline[n++] = arg[i++];
-		}
-
-		// Finish quoting the arg if needed.
-		if (has_whitespace && (n < (CMDLINE_LENGTH - 1)))
-			com_cmdline[n++] = '"';
-
-		// Add a space for the next arg, or bail out when max length hit.
-		if (n < (CMDLINE_LENGTH - 1))
-			com_cmdline[n++] = ' ';
-		else
-			break;
+		int chars_copied;
+		// The old convention for com_cmdline is that it starts with a space, and
+		// it ends with a space if there is enough room. Might as well preserve
+		// that behavior.
+		com_cmdline[0] = ' ';
+		chars_copied = Q_strncpy(com_cmdline + 1, CMDLINE_LENGTH - 1, cmdline, strlen(cmdline));
+		if (chars_copied < (CMDLINE_LENGTH - 2))
+			com_cmdline[chars_copied + 1] = ' ';
 	}
+	else
+	{
+		int		j, n;
+		qboolean	has_whitespace;
 
-	com_cmdline[n] = 0;
+		n = 0;
+
+		for (j=0 ; j<MAX_NUM_ARGVS && j<argc ; j++)
+		{
+			const char *arg = argv[j];
+			i = 0;
+
+			// See if we need to quote the arg.
+			if (strcspn(arg, whitespace) == strlen(arg))
+			{
+				has_whitespace = false;
+			}
+			else
+			{
+				has_whitespace = true;
+				if (n < (CMDLINE_LENGTH - 1))
+					com_cmdline[n++] = '"';
+			}
+
+			// Copy in the chars of the arg. Backslash any quote or backslash chars as
+			// necessary.
+			while ((n < (CMDLINE_LENGTH - 1)) && arg[i])
+			{
+				if ((arg[i] == '"') || ((!has_whitespace) && (arg[i] == '\\')))
+				{
+					com_cmdline[n++] = '\\';
+					if (n >= CMDLINE_LENGTH)
+						break;
+				}
+				com_cmdline[n++] = arg[i++];
+			}
+
+			// Finish quoting the arg if needed.
+			if (has_whitespace && (n < (CMDLINE_LENGTH - 1)))
+				com_cmdline[n++] = '"';
+
+			// Add a space for the next arg, or bail out when max length hit.
+			if (n < (CMDLINE_LENGTH - 1))
+				com_cmdline[n++] = ' ';
+			else
+				break;
+		}
+
+		com_cmdline[n] = 0;
+	}
 
 	safe = false;
 

--- a/common.h
+++ b/common.h
@@ -206,7 +206,7 @@ extern	const char	**com_argv;
 
 int   COM_FindNextParm (const char *parm, int start);
 void  COM_Init (void);
-void  COM_InitArgv (int argc, const char **argv);
+void  COM_InitArgv (int argc, const char **argv, const char *cmdline);
 void  COM_InitFilesystem (void);
 void *COM_LoadLibrary (const char *name);
 void  COM_UnloadLibrary (void *);

--- a/sys_linux.c
+++ b/sys_linux.c
@@ -626,7 +626,7 @@ int main (int argc, const char **argv)
 
 	memset (&parms, 0, sizeof(parms));
 
-	COM_InitArgv (argc, argv);
+	COM_InitArgv (argc, argv, NULL);
 	parms.argc = com_argc;
 	parms.argv = com_argv;
 

--- a/sys_win.c
+++ b/sys_win.c
@@ -789,7 +789,7 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	//   variables.
 	// - Parse command line ourselves, using the standard Microsoft rules for
 	//   C/C++ programs.
-	// - Get the unicode command line with CommandLineToArgvW and parse it
+	// - Get the unicode command line with GetCommandLineW and parse it
 	//   with CommandLineToArgvW. But then we need convert everything to ANSI
 	//   to stay compatible with the rest of the engine.
 

--- a/sys_win.c
+++ b/sys_win.c
@@ -821,9 +821,9 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	// Discard the unicode args.
 	LocalFree(wargv);
 
-	// Discard args past MAX_NUM_ARGVS, construct the com_cmdline var, and
-	// handle safe-mode switches.
-	COM_InitArgv (parms.argc, parms.argv);
+	// Discard args past MAX_NUM_ARGVS, construct the "cmdline" console var,
+	// and handle safe-mode switches.
+	COM_InitArgv (parms.argc, parms.argv, lpCmdLine);
 
 	parms.argc = com_argc;
 	parms.argv = com_argv;

--- a/sys_win.c
+++ b/sys_win.c
@@ -789,9 +789,9 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	//   variables.
 	// - Parse command line ourselves, using the standard Microsoft rules for
 	//   C/C++ programs.
-	// - Get the unicode command line with CommandLineToArgvW and parse it
-	//   with CommandLineToArgvW. But then we need convert everything to ANSI
-	//   to stay compatible with the rest of the engine.
+	// - Get the unicode command line with GetCommandLineW and parse it with
+	//   CommandLineToArgvW. But then we need convert everything to ANSI to
+	//   stay compatible with the rest of the engine.
 
 	// Let's do that last one. So:
 

--- a/sys_win.c
+++ b/sys_win.c
@@ -797,6 +797,9 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 
 	// Get the args in unicode.
 	wargv = CommandLineToArgvW(GetCommandLineW(), &(parms.argc));
+	// Cap argc at our internal max.
+	if (parms.argc > MAX_NUM_ARGVS)
+		parms.argc = MAX_NUM_ARGVS;
 	// Allocate space pointers to ANSI args.
 	parms.argv = Q_malloc(sizeof(char*) * parms.argc);
 	// First arg is always just empty-string.
@@ -821,8 +824,7 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	// Discard the unicode args.
 	LocalFree(wargv);
 
-	// Discard args past MAX_NUM_ARGVS, construct the "cmdline" console var,
-	// and handle safe-mode switches.
+	// Construct the "cmdline" console var and handle safe-mode switches.
 	COM_InitArgv (parms.argc, parms.argv, lpCmdLine);
 
 	parms.argc = com_argc;

--- a/sys_win.c
+++ b/sys_win.c
@@ -789,9 +789,9 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	//   variables.
 	// - Parse command line ourselves, using the standard Microsoft rules for
 	//   C/C++ programs.
-	// - Get the unicode command line with GetCommandLineW and parse it with
-	//   CommandLineToArgvW. But then we need convert everything to ANSI to
-	//   stay compatible with the rest of the engine.
+	// - Get the unicode command line with CommandLineToArgvW and parse it
+	//   with CommandLineToArgvW. But then we need convert everything to ANSI
+	//   to stay compatible with the rest of the engine.
 
 	// Let's do that last one. So:
 

--- a/sys_win.c
+++ b/sys_win.c
@@ -750,7 +750,6 @@ WinMain
 */
 HINSTANCE	global_hInstance;
 int			global_nCmdShow;
-char		*argv[MAX_NUM_ARGVS];
 static char	*empty_string = "";
 //HWND		hwnd_dialog;
 
@@ -760,6 +759,8 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	double		time, oldtime, newtime;
 	MEMORYSTATUS	lpBuffer;
 	static	char	cwd[1024];
+	LPWSTR		*wargv;
+	int		arg_num;
 	int		t;
 //	RECT		rect;
 
@@ -781,32 +782,47 @@ int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 
 	parms.basedir = cwd;
 
-	parms.argc = 1;
-	argv[0] = empty_string;
+	// We want to preserve spaces in the command-line arguments, which are not
+	// uncommon in path values for args (like -basedir value). A few ways we
+	// could do this:
+	// - Link with the VC++ runtime and use the generated __argc and __argv
+	//   variables.
+	// - Parse command line ourselves, using the standard Microsoft rules for
+	//   C/C++ programs.
+	// - Get the unicode command line with CommandLineToArgvW and parse it
+	//   with CommandLineToArgvW. But then we need convert everything to ANSI
+	//   to stay compatible with the rest of the engine.
 
-	while (*lpCmdLine && (parms.argc < MAX_NUM_ARGVS))
+	// Let's do that last one. So:
+
+	// Get the args in unicode.
+	wargv = CommandLineToArgvW(GetCommandLineW(), &(parms.argc));
+	// Allocate space pointers to ANSI args.
+	parms.argv = Q_malloc(sizeof(char*) * parms.argc);
+	// First arg is always just empty-string.
+	parms.argv[0] = empty_string;
+	// Loop through remaining args and convert them to ANSI.
+	for (arg_num = 1; arg_num < parms.argc; arg_num++)
 	{
-		while (*lpCmdLine && ((*lpCmdLine <= 32) || (*lpCmdLine > 126)))
-			lpCmdLine++;
-
-		if (*lpCmdLine)
-		{
-			argv[parms.argc] = lpCmdLine;
-			parms.argc++;
-
-			while (*lpCmdLine && ((*lpCmdLine > 32) && (*lpCmdLine <= 126)))
-				lpCmdLine++;
-
-			if (*lpCmdLine)
-			{
-				*lpCmdLine = 0;
-				lpCmdLine++;
-			}
-		}
+		// Find the size for the ANSI arg.
+		int arg_size = WideCharToMultiByte(
+			CP_ACP, // ANSI
+			0, // no special handling of unmapped chars
+			wargv[arg_num], // arg to process
+			-1, // arg is null-terminated
+			NULL, 0, // no output yet, just calculating size
+			NULL, NULL); // use default for unrepresented char
+		// Allocate space for the ANSI arg.
+		parms.argv[arg_num] = Q_malloc(arg_size);
+		// Fill the ANSI arg.
+		WideCharToMultiByte(CP_ACP, 0, wargv[arg_num], -1,
+			parms.argv[arg_num], arg_size, NULL, NULL);
 	}
+	// Discard the unicode args.
+	LocalFree(wargv);
 
-	parms.argv = argv;
-
+	// Discard args past MAX_NUM_ARGVS, construct the com_cmdline var, and
+	// handle safe-mode switches.
 	COM_InitArgv (parms.argc, parms.argv);
 
 	parms.argc = com_argc;


### PR DESCRIPTION
On modern Windows systems, any arg that is a path value is somewhat likely to have spaces in it.

Linux and SDL builds for Quake tend to handle these correctly, but various non-SDL Windows builds don't really. Let's fix it here!

The main change is in WinMain in sys_win.c, to make sure we interpret the argument tokens from the command line correctly. See the code comments for more details.

---

COM_InitArgv in common.c needs an ancillary change, to properly show arguments-with-spaces in the constructed "cmdline" console variable. From a user's POV this is muuuch less interesting than the main change, since the cmdline variable is just an informative thing (and rarely used I think). But getting it right is somewhat tricky.

The problem looks like this:
- We want to populate a var with the command line used to launch Quake.
- We are trying to reconstruct that command line from the argument vector.
- Proper reconstruction depends on the arg-quoting conventions in the environment used to launch Quake.

I settled on an approach that is not super-crossplatform-elegant but which has minimal churn to the existing code:
- COM_InitArgv will use a bash-like quoting convention for command-line reconstruction. Pretty simple stuff: quote arguments that contain whitespace, backslash-quote any actual quote chars, and backslash-quote backslash chars as needed.
- If the caller doesn't want that convention (which, in Windows, we don't) then the caller can provide the actual command line if that's available, to be used instead of reconstructing from the arg vector. On Windows, the command line is in fact available, so provide it.

---

I've been using this with the Windows build... works fine, populates the cmdline var as expected. Example screenshot here from a launch using a basedir path that contains spaces:

![e1m3_000](https://cloud.githubusercontent.com/assets/2068148/2811848/a0710d3a-ce34-11e3-9b43-1e16dc75d8d4.jpg)

The Linux build compiles and starts, but I don't have a graphical Linux environment yet that can run reQuiem (it fails with XF86DGANoDirectVideoMode). So you'll probably want to sanity-test this on Linux still. Or wait until I can. :-) Maybe there's a way to get my CentOS VM (VMware Fusion) capable of running this.
