### PR TITLE
fix listen-server crash

### DIFF
--- a/sbar.c
+++ b/sbar.c
@@ -1368,6 +1368,10 @@ void Sbar_DeathmatchOverlay (void)
 //	scr_copyeverything = 1;
 //	scr_fullupdate = 0;
 
+	// Abort if not fully signed on yet.
+	if (cls.signon != SIGNONS)
+		return;
+
 	xofs = (vid.width - 320) >> 1;
 
 #ifdef HEXEN2_SUPPORT
@@ -1438,6 +1442,10 @@ void Sbar_MiniDeathmatchOverlay (int sbarlines)
 	int		i, k, l, top, bottom, x, y, f, numlines;
 	char		num[12];
 	scoreboard_t	*s;
+
+	// Abort if not fully signed on yet.
+	if (cls.signon != SIGNONS)
+		return;
 
 	if (vid.width < 512 || !sbarlines)
 		return;


### PR DESCRIPTION
This is a fix for issue #8. The comments on that issue describe the problem.
This change fixes that issue and is also just generally correct in that we
shouldn't be drawing scoreboards if we aren't even signed into the game yet.

However it would be cool if a Quake engine coding veteran could verify that
this particular change is the best (least fragile) way of addressing the issue.
I've chosen the "bail out at the last minute" approach, and it might be that
a higher-level fix to the control flow would be better.
