### PR TITLE
don't crash on PF_objerror

### DIFF
--- a/pr_cmds.c
+++ b/pr_cmds.c
@@ -129,7 +129,7 @@ void PF_objerror (void)
 	ED_Print (ed);
 	ED_Free (ed);
 
-	Host_Error ("Program error");
+	//Host_Error ("Program error"); //johnfitz -- by design, this should not be fatal
 }
 
 


### PR DESCRIPTION
This resolves issue #23. Tested using impdm1.

I included JF's comment to make it clear that this is just lifted from
Fitzquake.
