### PR TITLE
skip Sbar_Draw when console is fullscreen

### DIFF
--- a/sbar.c
+++ b/sbar.c
@@ -1189,7 +1189,9 @@ void Sbar_Draw (void)
 	qboolean	headsup;	// joe
 	int			sbarlines;
 
-//	if (scr_con_current == vid.height)
+	if (scr_con_current == vid.height)
+		return;		// console is full screen
+
 	if (cls.state != ca_connected)
 		return;
 


### PR DESCRIPTION
This addresses issue #8.

A quick summary of issue #8: when starting a listen server, reQuiem crashes
because it tries to do Sbar_Draw before a necessary data structure (cl.scores)
is allocated.

Other Quake engines don't have this problem because they have this at the top
of Sbar_Draw:

``` c
 if (scr_con_current == vid.height)
  return;  // console is full screen
```

Of course that isn't actually checking to see if the necessary data structures
exist... it only indirectly protects the code by virtue of the data being OK
by the time Quake gets to the point of rendering the scene and exiting the
fullscreen console. For whatever reason, it also keeps things in an OK state
when transitioning between maps after the listen server is running.

reQuiem has that check commented out and does this instead:

``` c
 if (cls.state != ca_connected)
  return;
```

I'm not sure if that's trying to guard against exactly the same sorts of
issues, but in any case, it doesn't guard against this particular problem as
reQuiem passes through that check and crashes.

Rather than delete JDH's check, I've just added the original one back in, so
that the top of Sbar_Draw now does:

``` c
 if (scr_con_current == vid.height)
  return;  // console is full screen

 if (cls.state != ca_connected)
  return;
```

If we get past both checks then surely we'll be fine!

Note that there are a LOT of other checks of scr_con_current in reQuiem,
including other identical checks for fullscreen console, so this is still a
valid piece of info in reQuiem.

I've tested this build of reQuiem by starting a frikbots match and running
through a few maps. Seems kosher.

It might seem a little wasteful to leave JDH's check in place but I'm not sure
that the old check guards against a superset of the new check's conditions.
Unless someone knows for sure, I'd leave both of the checks in place... they're
very fast.
