### PR TITLE
exec requiem.cfg even if no autoexec.cfg

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -403,6 +403,14 @@ void Cmd_Exec_f (cmd_source_t src)
 		if (!f)
 		{
 			Con_Printf ("couldn't exec %s\n", name);
+			// Normally requiem.cfg is executed after autoexec.cfg (see below). If
+			// this was an attempt to exec autoexec.cfg, set the "done that" flag
+			// and exec requiem.cfg now.
+			if (!Q_strcasecmp(p, "autoexec.cfg") && !id1_autoexec_done)
+			{
+				Cbuf_InsertText ("exec reQuiem.cfg\n", SRC_COMMAND);
+				id1_autoexec_done = true;
+			}
 			return;
 		}
 	}


### PR DESCRIPTION
Resolves issue #29.

requiem.cfg is intended to be exec'd after autoexec.cfg. The solution to
issue #29 is to perform this explicit exec even if there is no autoexec.cfg...
do it after the failed attempt.

The code is a bit of if-spaghetti here so I didn't want to refactor it. I
particularly don't want to disturb the management of the hunk allocations.
This means a bit of code-duplication in the solution, but it's minor.

I preserved the existing behavior of only doing this implicit exec once (via
the id1_autoexec_done flag). I.e. after starting Quake, if you manually type
"exec autoexec.cfg" into the console then it will exec autoexec.cfg again (or
try to), but it's not going to re-exec requiem.cfg afterward. Of course you
can manually exec requiem.cfg as many times as you want.
