### PR TITLE
don't put duplicate entries into cl_visedicts

### DIFF
--- a/gl_refrag.c
+++ b/gl_refrag.c
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifndef RQM_SV_ONLY
 
+extern qboolean	scr_update_in_frame;
+
 mnode_t	*r_pefragtopnode;
 
 
@@ -211,7 +213,7 @@ void R_StoreEfrags (efrag_t **ppefrag)
 		case mod_md3:
 		case mod_brush:
 		case mod_sprite:
-			if (pent->visframe != r_framecount)
+			if (scr_update_in_frame && pent->visframe != r_framecount)
 			{
 				if (cl_numvisedicts < MAX_VISEDICTS)
 					cl_visedicts[cl_numvisedicts++] = pent;

--- a/host.c
+++ b/host.c
@@ -40,6 +40,7 @@ Memory is cleared / released when a server or client begins, not when they end.
 quakeparms_t	host_parms;
 
 qboolean	host_initialized;		// true if into command execution
+qboolean	scr_update_in_frame;		// true while calling SCR_UpdateScreen from _Host_Frame
 
 double		host_frametime;
 double		host_time;
@@ -839,7 +840,9 @@ void _Host_Frame (double time)
 		time1 = Sys_DoubleTime ();
 
 	// update video
+	scr_update_in_frame = true;
 	SCR_UpdateScreen ();
+	scr_update_in_frame = false;
 
 	if (host_speeds.value)
 		time2 = Sys_DoubleTime ();


### PR DESCRIPTION
Resolves issue #9.

Summary:

skychain is a linked list (through texturechain pointers) of surfaces. Surfaces are appended to skychain while processing cl_visedicts. If there are duplicates in cl_visedicts then loops can be formed in the skychain. If there are loops in the skychain then R_DrawSky will never terminate. (This is all contingent on certain cvars used to choose the sky style, but this is the default behavior.)

Solution:

Dups in cl_visedicts are generally bad, so let's eliminate those. This will also fix the skychain issue.

Things other than R_StoreEfrags that modify cl_visedicts all happen under _Host_Frame:

```
_Host_Frame
  CL_ReadFromServer (if connected)
    CL_RelinkEntities resets cl_numvisedicts and then adds to cl_visedicts
    CL_LinkProjectiles (if qw) adds to cl_visedicts
    CL_UpdateStreams (if hexen2) adds to cl_visedicts
  CL_UpdateEffects (if hexen2 and connected) adds to cl_visedicts
```

That's all cool!

Then there's R_StoreEfrags. It is down the callstack from SCR_UpdateScreen.

SCR_UpdateScreen is called from: _Host_Frame, Con_Keydown, Con_Print, Movie_TestFPS, SCR_BeginLoadingPlaque, and SCR_ModalMessage.

The only time we actually want R_StoreEfrags to add to cl_visedicts is in the case where SCR_UpdateScreen is called from _Host_Frame. So let's enforce that with a global flag.

This change fixes the specific reported issue with czg07. Giving it some burn-in testing now to see if it causes (or solves?) other issues.
