### PR TITLE
don't generate bad svc_spawnstatic commands at changelevel

### DIFF
--- a/pr_cmds.c
+++ b/pr_cmds.c
@@ -2144,7 +2144,7 @@ void PF_makestatic (void)
 	MSG_WriteSpawnstatic (&sv.signon, ent);
 
 // JDH: if there's a local client running, send it a message
-	if (svs.clients[0].spawned && svs.clients[0].netconnection && !svs.clients[0].netconnection->socket)
+	if (allow_postcache && svs.clients[0].spawned && svs.clients[0].netconnection && !svs.clients[0].netconnection->socket)
 		MSG_WriteSpawnstatic (&svs.clients[0].message, ent);
 
 // throw the entity away now

--- a/pr_cmds.c
+++ b/pr_cmds.c
@@ -2144,7 +2144,7 @@ void PF_makestatic (void)
 	MSG_WriteSpawnstatic (&sv.signon, ent);
 
 // JDH: if there's a local client running, send it a message
-	if (allow_postcache && svs.clients[0].spawned && svs.clients[0].netconnection && !svs.clients[0].netconnection->socket)
+	if ((sv.state == ss_active) && svs.clients[0].spawned && svs.clients[0].netconnection && !svs.clients[0].netconnection->socket)
 		MSG_WriteSpawnstatic (&svs.clients[0].message, ent);
 
 // throw the entity away now


### PR DESCRIPTION
Resolves issue #16.

PF_makestatic has some additional code for supporting the "create" command.
However, this can incorrectly run during a changelevel (because the
client spawned flag is true), pushing extraneous svc_spawnstatic commands to
the client.

The client will parse the commands incorrectly because it hasn't yet
received the svc_serverinfo command that sets the protocol version. This
results in some "command parsing roulette" which may or may not cause the
level load to fail.

Adding this check of sv.state ensures that the extra code will not be run
during changelevel. I left the other checks in place just to be safe... the
create command is a test/debug command in any case so a few extra checks are
not a performance concern.

If we were to be the most precise & complete about the bit of functionality in
this function, we should probably send the svc_spawnstatic message to all
clients. Leave it up to Host_Create_f to decide if the "create" command
should be limited to the single-local-client case or not. But, let's do
minimal changes for now and just fix the bug.

The test cases of the zendar and masque map changes work now. The create
command still works too.
