### PR TITLE
always allow binding toggleconsole from menu

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -3771,10 +3771,11 @@ qboolean M_Keys_Key (int k, qboolean down)
 		if (k != K_ESCAPE)
 		{
 			S_LocalSound (gMenuSounds[0]);
-		//	if (k == '`')
-		//		return true;
 
-			if (keycmds == keycmds_other)
+			// Lock out some keys from being bound from the "Other Controls"
+			// menu (except for the toggleconsole binding).
+			cmdname = keycmds[menu_current->cursor].cmd;
+			if ((keycmds == keycmds_other) && Q_strcasecmp(cmdname, "toggleconsole"))
 			{
 				if (k & 0xFFFFFF00)
 				{
@@ -3791,7 +3792,6 @@ qboolean M_Keys_Key (int k, qboolean down)
 				}
 			}
 
-			cmdname = keycmds[menu_current->cursor].cmd;
 			M_FindKeysForCommand (cmdname, keys);
 			if (keys[1] != -1)
 				M_UnbindCommand (cmdname);


### PR DESCRIPTION
Resolves issue #28.

"Reserved keys" are described in more detail in the issue, although actually
there's even more to it than I cover there.

It seems like there is some partially-implemented stuff going on, across a few
different but related features all trying to make the creating and using of
key binds a little smarter. Touching any part of the various "reserved key"
definitions/interpretations is likely to affect multiple behaviors.

Rather than try to untangle the spaghetti I'm going to just deal with this
particular Gordian knot -- pardon the mixed metaphors -- and always allow the
toggleconsole binding from the "Other Controls" menu, regardless of what key
is selected. If you happen to pick a key that you later find to be
inconvenient then OK, just bind it to something better.

The key restrictions don't seem as onerous for the other items in that menu
(like screenshot or quicksave) so I left those alone.
