### PR TITLE
after creating a compressed demo, add the dzip to com_searchpaths

### DIFF
--- a/cl_demo.c
+++ b/cl_demo.c
@@ -1298,7 +1298,7 @@ void DZCompressError (void)
 	dz_app_op = DZ_OP_NONE;
 }
 
-void DZCompressFinish (void)
+void DZCompressFinish (const char *dzname)
 {
 	char	dempath[MAX_OSPATH];
 
@@ -1306,6 +1306,9 @@ void DZCompressFinish (void)
 
 	Q_snprintfz (dempath, sizeof(dempath), "%s/%s", com_gamedir, cl_demo_filepath);
 	remove (dempath);
+	// If .dz file, and dzlib_loaded, then should be added to searchpaths.
+	if (dzlib_loaded && !Q_strcasecmp(COM_FileExtension (dzname), "dz"))
+		COM_AddDzipByName (dzname);
 	Con_Print ("Done!\n");
 }
 
@@ -1329,7 +1332,7 @@ static qboolean CL_VerifyCompressedDemo (const char *dzname)
 		dz_app_op = DZ_OP_NONE;		// in case compression step was done by dz app
 		if (Dzip_Verify (dzpath))
 		{
-			DZCompressFinish ();
+			DZCompressFinish (dzname);
 			return true;
 		}
 		remove (dzpath);
@@ -1445,7 +1448,7 @@ DOCOMPRESS:
 				if (!DZWaitForApp () || (dz_exitcode != DZ_APP_NOERR))
 					goto ERROR_EXIT;
 
-				DZCompressFinish ();
+				DZCompressFinish (dz_filename);
 				dz_app_op = DZ_OP_NONE;
 			}
 		}
@@ -1951,7 +1954,7 @@ static void CheckDZipCompletion (void)
 		if (dz_exitcode == DZ_APP_NOERR)
 		{
 			dz_app_op = DZ_OP_NONE;
-			DZCompressFinish ();
+			DZCompressFinish (dz_filename);
 			return;
 		}
 	}

--- a/common_file.c
+++ b/common_file.c
@@ -1695,10 +1695,21 @@ COM_AddDzip
 */
 int COM_AddDzip (com_fileinfo_t *file, int count, unsigned int param)
 {
+	return COM_AddDzipByName (file->name);
+}
+
+/*
+================
+COM_AddDzipByName
+- used by callback above, and also when adding newly created dzip
+================
+*/
+int COM_AddDzipByName (char *name)
+{
 	char	filepath[MAX_OSPATH];
 	pack_t	*pak;
 
-	Q_snprintfz (filepath, sizeof(filepath), "%s/%s", com_gamedir, file->name);
+	Q_snprintfz (filepath, sizeof(filepath), "%s/%s", com_gamedir, name);
 
 	pak = Dzip_LoadFileList (filepath);
 	if (pak)


### PR DESCRIPTION
Resolves issue #30.

com_searchpaths has existing .dz files added to it at startup time. If we
create a new .dz file we should add it too.

Note that we'll only add .dz files (not .zip files) to the searchpaths, to
mimic the startup-time behavior which also only looks for .dz files.

Tested by doing demo compress with the dzip app and/or library installed.
