### PR TITLE
account for screen/viewport differences in FOV calc

### DIFF
--- a/gl_screen.c
+++ b/gl_screen.c
@@ -867,22 +867,19 @@ static void SCR_CalcRefdef (void)
 	if (scr_fov_adapt.value)
 	{
 		// "auto" FOV: treat fov value as horizontal FOV for 4:3 aspect ratio
-		// 1) Find what the width dimension would be for the current height,
-		//    if the aspect ratio were 4:3.
-		float width_4_3 = r_refdef.vrect.height * 4.0 / 3.0;
-		// 2) Calculate vertical FOV from the fov value and the "4:3 width".
-		r_refdef.fov_y = CalcFov (scr_fov.value, width_4_3, r_refdef.vrect.height);
-		// 3) Calculate actual horizontal FOV from vertical FOV.
-		r_refdef.fov_x = CalcFov (r_refdef.fov_y, r_refdef.vrect.height, r_refdef.vrect.width);	
+		// Find what the screen width dimension would be for the current screen
+		// height, if the screen aspect ratio were 4:3. Assuming scr_fov.value is
+		// the FOV at that width, then find the appropriate FOV for the current
+		// screen width. Use that for the viewport's horizontal FOV.
+		r_refdef.fov_x = CalcFov (scr_fov.value, vid.height * 4.0 / 3.0, vid.width);
 	}
 	else
 	{
-		// "manual" FOV: treat fov value as horizontal FOV.
-		// 1) Calculate vertical FOV from the fov value and the width.
-		r_refdef.fov_y = CalcFov (scr_fov.value, r_refdef.vrect.width, r_refdef.vrect.height);
-		// 2) Set horizontal FOV directly.
+		// "manual" FOV: treat fov value as the viewport's horizontal FOV.
 		r_refdef.fov_x = scr_fov.value;
 	}
+	// Always derive the viewport's vertical FOV from its horizontal FOV.
+	r_refdef.fov_y = CalcFov (r_refdef.fov_x, r_refdef.vrect.width, r_refdef.vrect.height);
 
 	scr_vrect = r_refdef.vrect;
 }


### PR DESCRIPTION
Resolves issue #15 (for sure this time).

This new calculation for auto-FOV preserves the original Quake behavior of
having a fixed horizontal FOV even when the viewport shrinks within the screen.

With these changes, reQuiem at 640x480 with cl_sbar 1 shows the same view as
GLQuake at 640x480, given a viewsize of 100 in both cases (which doesn't fill
the screen because of the statusbar).

When you start shrinking the viewport (decreasing viewsize), reQuiem's display
is a little different than GLQuake's, but that's because reQuiem's viewport
isn't as tall as GLQuake's once you start shrinking it. That is a different
issue (if it could be considered an issue at all); the relevant thing for this
change is that the horizontal FOV of the viewport is the same.

Also: if the screen's current aspect ratio is 4:3, then changing fov_adapt will
(correctly) not change the end result of the FOV calculation. The math will only
give varying results for varying values of fov_adapt if the screen has some
other aspect ratio.
