### PR TITLE
fix crosshair placement

### DIFF
--- a/gl_draw.c
+++ b/gl_draw.c
@@ -1588,7 +1588,7 @@ Draw_Crosshair		-- joe, from FuhQuake
 */
 void Draw_Crosshair (void)
 {
-	float		x, y, ofsx, ofsy, sh, th, sl, tl;
+	float		x, y, ofs, sh, th, sl, tl;
 	byte		col[4];
 	extern vrect_t	scr_vrect;
 
@@ -1622,8 +1622,6 @@ void Draw_Crosshair (void)
 			if (crosshairimage_loaded)
 			{
 				GL_Bind (crosshairpic.texnum);
-				ofsx = crosshairpic.width / 2.0;
-				ofsy = crosshairpic.height / 2.0;
 				sh = crosshairpic.sh;
 				sl = crosshairpic.sl;
 				th = crosshairpic.th;
@@ -1632,24 +1630,21 @@ void Draw_Crosshair (void)
 			else
 			{
 				GL_Bind (crosshairtextures[(int)crosshair.value-1]);
-				ofsx = 4.0;
-				ofsy = 4.0;
 				tl = sl = 0;
 				sh = th = 1;
 			}
 
-			ofsx *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
-			ofsy *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
+			ofs = 4.0 * bound(0, crosshairsize.value, 20);
 
 			glBegin (GL_QUADS);
 			glTexCoord2f (sl, tl);
-			glVertex2f (x - ofsx, y - ofsy);
+			glVertex2f (x - ofs, y - ofs);
 			glTexCoord2f (sh, tl);
-			glVertex2f (x + ofsx, y - ofsy);
+			glVertex2f (x + ofs, y - ofs);
 			glTexCoord2f (sh, th);
-			glVertex2f (x + ofsx, y + ofsy);
+			glVertex2f (x + ofs, y + ofs);
 			glTexCoord2f (sl, th);
-			glVertex2f (x - ofsx, y + ofsy);
+			glVertex2f (x - ofs, y + ofs);
 			glEnd ();
 		}
 		/*else

--- a/gl_draw.c
+++ b/gl_draw.c
@@ -1588,7 +1588,7 @@ Draw_Crosshair		-- joe, from FuhQuake
 */
 void Draw_Crosshair (void)
 {
-	float		x, y, ofs1, ofs2, sh, th, sl, tl;
+	float		x, y, ofsx, ofsy, sh, th, sl, tl;
 	byte		col[4];
 	extern vrect_t	scr_vrect;
 
@@ -1622,8 +1622,8 @@ void Draw_Crosshair (void)
 			if (crosshairimage_loaded)
 			{
 				GL_Bind (crosshairpic.texnum);
-				ofs1 = 4 - 4.0 / crosshairpic.width;
-				ofs2 = 4 + 4.0 / crosshairpic.width;
+				ofsx = crosshairpic.width / 2.0;
+				ofsy = crosshairpic.height / 2.0;
 				sh = crosshairpic.sh;
 				sl = crosshairpic.sl;
 				th = crosshairpic.th;
@@ -1632,24 +1632,26 @@ void Draw_Crosshair (void)
 			else
 			{
 				GL_Bind (crosshairtextures[(int)crosshair.value-1]);
-				ofs1 = 3.5;
-				ofs2 = 4.5;
+				ofsx = 4.0;
+				ofsy = 4.0;
 				tl = sl = 0;
 				sh = th = 1;
 			}
 
-			ofs1 *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
-			ofs2 *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
+			ofsx *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
+			ofsy *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
 
+			glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+			glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 			glBegin (GL_QUADS);
 			glTexCoord2f (sl, tl);
-			glVertex2f (x - ofs1, y - ofs1);
+			glVertex2f (x - ofsx, y - ofsy);
 			glTexCoord2f (sh, tl);
-			glVertex2f (x + ofs2, y - ofs1);
+			glVertex2f (x + ofsx, y - ofsy);
 			glTexCoord2f (sh, th);
-			glVertex2f (x + ofs2, y + ofs2);
+			glVertex2f (x + ofsx, y + ofsy);
 			glTexCoord2f (sl, th);
-			glVertex2f (x - ofs1, y + ofs2);
+			glVertex2f (x - ofsx, y + ofsy);
 			glEnd ();
 		}
 		/*else

--- a/gl_draw.c
+++ b/gl_draw.c
@@ -814,7 +814,7 @@ qboolean OnChange_gl_crosshairimage (cvar_t *var, const char *string)
 	namelist[0] = string;
 	namelist[1] = NULL;
 
-	if (!(pic = GL_LoadPicImage_MultiSource (crosshair_pathlist, namelist, "crosshair", TEX_ALPHA, 0)))
+	if (!(pic = GL_LoadPicImage_MultiSource (crosshair_pathlist, namelist, "crosshair", TEX_ALPHA | TEX_NOTILE, 0)))
 	{
 		crosshairimage_loaded = false;
 		if (key_dest != key_menu)
@@ -987,7 +987,7 @@ void Draw_Init (void)
 		for (j = 0; j < 8*8; j++)
 			data24[j] = crosshairdata[i][j] ? MAKEGREY(crosshairdata[i][j]) : 0;
 
-		crosshairtextures[i] = GL_LoadTexture ("", 8, 8, (byte *)data24, TEX_ALPHA, 4);
+		crosshairtextures[i] = GL_LoadTexture ("", 8, 8, (byte *)data24, TEX_ALPHA | TEX_NOTILE, 4);
 		glTexParameterf (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameterf (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	}
@@ -1641,8 +1641,6 @@ void Draw_Crosshair (void)
 			ofsx *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
 			ofsy *= /*(vid.width / 320) * */bound(0, crosshairsize.value, 20);
 
-			glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-			glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 			glBegin (GL_QUADS);
 			glTexCoord2f (sl, tl);
 			glVertex2f (x - ofsx, y - ofsy);


### PR DESCRIPTION
Resolves issue #53.

Center the 8x8 quad that the crosshair is drawn on, and clamp the crosshair texture to the quad (use TEX_NOTILE).

Not sure why the code was the way it was. More discussion in the issue, and at http://forums.inside3d.com/viewtopic.php?f=3&t=5528
