### PR TITLE
always-mouselook cvar

### DIFF
--- a/cl_input.c
+++ b/cl_input.c
@@ -130,9 +130,8 @@ void KeyUp (kbutton_t *b)
 
 void RecalcMouselook (qboolean global_mlook)
 {
-	qboolean keydown = ((in_mlook.state & 1) != 0);
 	qboolean old_mouselook = mouselook;
-	mouselook = (keydown != global_mlook);
+	mouselook = (global_mlook || ((in_mlook.state & 1) != 0));
 	// If disabling mouselook, and lookspring is enabled, handle that.
 	if (!mouselook && lookspring.value && old_mouselook)
 		V_StartPitchDrift ();

--- a/cl_input.c
+++ b/cl_input.c
@@ -54,6 +54,8 @@ kbutton_t	in_lookup, in_lookdown, in_moveleft, in_moveright;
 kbutton_t	in_strafe, in_speed, in_use, in_jump, in_attack;
 kbutton_t	in_up, in_down;
 
+qboolean		mouselook;
+
 int		in_impulse;
 
 
@@ -126,14 +128,27 @@ void KeyUp (kbutton_t *b)
 	b->state |= 4; 		// impulse up
 }
 
+void RecalcMouselook (qboolean global_mlook)
+{
+	qboolean keydown = ((in_mlook.state & 1) != 0);
+	qboolean old_mouselook = mouselook;
+	mouselook = (keydown != global_mlook);
+	// If disabling mouselook, and lookspring is enabled, handle that.
+	if (!mouselook && lookspring.value && old_mouselook)
+		V_StartPitchDrift ();
+}
+
 void IN_KLookDown (cmd_source_t src)    {KeyDown(&in_klook);}
 void IN_KLookUp (cmd_source_t src)      {KeyUp(&in_klook);}
-void IN_MLookDown (cmd_source_t src)    {KeyDown(&in_mlook);}
+void IN_MLookDown (cmd_source_t src)
+{
+	KeyDown(&in_mlook);
+	RecalcMouselook (m_look.value != 0.0);
+}
 void IN_MLookUp (cmd_source_t src)
 {
 	KeyUp(&in_mlook);
-	if (!(in_mlook.state & 1) && lookspring.value)
-		V_StartPitchDrift ();
+	RecalcMouselook (m_look.value != 0.0);
 }
 void IN_UpDown(cmd_source_t src)        {KeyDown(&in_up);}
 void IN_UpUp(cmd_source_t src)          {KeyUp(&in_up);}

--- a/cl_main.c
+++ b/cl_main.c
@@ -42,7 +42,7 @@ cvar_t	cl_nolerp   = {"cl_nolerp",   "0"};
 cvar_t	lookspring  = {"lookspring",  "0", CVAR_FLAG_ARCHIVE};
 cvar_t	lookstrafe  = {"lookstrafe",  "0", CVAR_FLAG_ARCHIVE};
 cvar_t	sensitivity = {"sensitivity", "3", CVAR_FLAG_ARCHIVE};
-cvar_t	m_look      = {"m_look",      "0", CVAR_FLAG_ARCHIVE, OnChange_m_look};
+cvar_t	m_look      = {"m_look",      "1", CVAR_FLAG_ARCHIVE, OnChange_m_look};
 
 cvar_t	m_pitch     = {"m_pitch", "0.022", CVAR_FLAG_ARCHIVE};
 cvar_t	m_yaw       = {"m_yaw",   "0.022", CVAR_FLAG_ARCHIVE};

--- a/cl_main.c
+++ b/cl_main.c
@@ -27,6 +27,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define CONNECT_DEBUG		// tracking down elusive bug in CL_EstablishConnection
 
+qboolean OnChange_m_look (cvar_t *var, const char *value)
+{
+	RecalcMouselook (Q_atof(value) != 0.0);
+	return false;		// allow change
+}
 
 // we need to declare some mouse variables here, because the menu system
 // references them even when on a unix system.
@@ -37,6 +42,7 @@ cvar_t	cl_nolerp   = {"cl_nolerp",   "0"};
 cvar_t	lookspring  = {"lookspring",  "0", CVAR_FLAG_ARCHIVE};
 cvar_t	lookstrafe  = {"lookstrafe",  "0", CVAR_FLAG_ARCHIVE};
 cvar_t	sensitivity = {"sensitivity", "3", CVAR_FLAG_ARCHIVE};
+cvar_t	m_look      = {"m_look",      "0", CVAR_FLAG_ARCHIVE, OnChange_m_look};
 
 cvar_t	m_pitch     = {"m_pitch", "0.022", CVAR_FLAG_ARCHIVE};
 cvar_t	m_yaw       = {"m_yaw",   "0.022", CVAR_FLAG_ARCHIVE};
@@ -1689,6 +1695,7 @@ void CL_Init (void)
 	Cvar_RegisterBool (&lookspring);
 	Cvar_RegisterBool (&lookstrafe);
 	Cvar_RegisterFloat (&sensitivity, 1, 11);
+	Cvar_RegisterBool (&m_look);
 
 	Cvar_RegisterFloat (&m_pitch, -1, 1);
 	Cvar_RegisterFloat (&m_yaw, -1, 1);		// JDH: is range correct??
@@ -1729,6 +1736,8 @@ void CL_Init (void)
 	Cmd_AddCommand ("stop", CL_Stop_f, 0);
 	Cmd_AddCommand ("playdemo", CL_PlayDemo_f, 0);
 	Cmd_AddCommand ("timedemo", CL_TimeDemo_f, 0);
+
+	RecalcMouselook (m_look.value != 0.0);
 }
 
 #endif		//#ifndef RQM_SV_ONLY

--- a/client.h
+++ b/client.h
@@ -270,6 +270,7 @@ extern	cvar_t	cl_pitchdriftspeed;
 extern	cvar_t	lookspring;
 extern	cvar_t	lookstrafe;
 extern	cvar_t	sensitivity;
+extern	cvar_t	m_look;
 
 extern	cvar_t	m_pitch;
 extern	cvar_t	m_yaw;
@@ -364,7 +365,8 @@ typedef struct
 	int		state;			// low bit is down state
 } kbutton_t;
 
-extern	kbutton_t	in_mlook, in_klook;
+extern 	qboolean 	mouselook;
+extern 	kbutton_t 	in_klook;
 extern 	kbutton_t 	in_strafe;
 extern 	kbutton_t 	in_speed;
 
@@ -387,6 +389,8 @@ void IN_CrouchUp (cmd_source_t src);
 void IN_infoPlaqueDown (cmd_source_t src);
 void IN_infoPlaqueUp (cmd_source_t src);
 #endif
+
+void RecalcMouselook (qboolean global_mlook);
 
 // cl_demo.c
 extern qboolean	cl_demoseek;

--- a/in_win.c
+++ b/in_win.c
@@ -999,15 +999,15 @@ void IN_MouseMove (usercmd_t *cmd)
 	mouse_y *= sensitivity.value;
 
 // add mouse X/Y movement to cmd
-	if ((in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1)))
+	if ((in_strafe.state & 1) || (lookstrafe.value && mouselook))
 		cmd->sidemove += m_side.value * mouse_x;
 	else
 		cl.viewangles[YAW] -= m_yaw.value * mouse_x;
 
-	if (in_mlook.state & 1)
+	if (mouselook)
 		V_StopPitchDrift ();
 
-	if ((in_mlook.state & 1) && !(in_strafe.state & 1))
+	if (mouselook && !(in_strafe.state & 1))
 	{
 		cl.viewangles[PITCH] += m_pitch.value * mouse_y;
 		cl.viewangles[PITCH] = bound (-70, cl.viewangles[PITCH], 80);
@@ -1403,7 +1403,7 @@ void IN_JoyMove (usercmd_t *cmd)
 		switch (dwAxisMap[i])
 		{
 		case AxisForward:
-			if ((joy_advanced.value == 0.0) && (in_mlook.state & 1))
+			if ((joy_advanced.value == 0.0) && mouselook)
 			{
 				// user wants forward control to become look control
 				if (fabs(fAxisValue) > joy_pitchthreshold.value)
@@ -1440,7 +1440,7 @@ void IN_JoyMove (usercmd_t *cmd)
 			break;
 
 		case AxisTurn:
-			if ((in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1)))
+			if ((in_strafe.state & 1) || (lookstrafe.value && mouselook))
 			{
 				// user wants turn control to become side control
 				if (fabs(fAxisValue) > joy_sidethreshold.value)
@@ -1460,7 +1460,7 @@ void IN_JoyMove (usercmd_t *cmd)
 			break;
 
 		case AxisLook:
-			if (in_mlook.state & 1)
+			if (mouselook)
 			{
 				if (fabs(fAxisValue) > joy_pitchthreshold.value)
 				{

--- a/menu.c
+++ b/menu.c
@@ -3528,7 +3528,7 @@ keycmd_t keycmds_game[] =
 	{"+jump", 			"Jump / Swim up"},
 	{"+strafe", 		"Strafe"},
 	{"centerview", 		"Center view"},
-	{"+mlook", 			"Mouselook on/off"},
+	{"+mlook", 			"Mouse look"},
 	{"+moveup",			"Swim up"},
 	{"+movedown",		"Swim down"},
 	{"+left", 			"Turn left"},

--- a/menu.c
+++ b/menu.c
@@ -580,6 +580,7 @@ menu_t menu_controls =
 		{                      "", NULL, NULL, M_ITEM_DISABLED},
 		{           "Mouse Speed", NULL, &sensitivity, M_ITEM_SLIDER},
 		{            "Always Run", NULL, &cl_forwardspeed},
+		{      "Always Mouselook", NULL, &m_look},
 		{          "Invert Mouse", NULL, &m_pitch},
 		{            "Lookspring", NULL, &lookspring},
 		{            "Lookstrafe", NULL, &lookstrafe},
@@ -2431,7 +2432,7 @@ void M_AdjustSliders (menu_t *menu, int dir, int key)
 		newval = bound (100, newval, 1000);
 		Cvar_SetValueDirect (var, newval);
 	}
-	else if ((var == &vid_vsync) || (var == &lookspring) || (var == &lookstrafe))
+	else if ((var == &vid_vsync) || (var == &lookspring) || (var == &lookstrafe) || (var == &m_look))
 	{
 		Cvar_SetValueDirect (var, !var->value);
 	}
@@ -2818,7 +2819,7 @@ void M_Controls_DrawVar (cvar_t *var, int y, qboolean selected)
 //		M_DrawCheckbox (M_VARLEFT, y, _windowed_mouse.value);
 		M_Print (M_VARLEFT, y, (!var->value ? "off" : (var->value == 1) ? "auto" : "on"));
 	}
-	else		// lookspring, lookstrafe
+	else		// lookspring, lookstrafe, always mouselook
 	{
 		M_DrawCheckbox (M_VARLEFT, y, var->value);
 	}
@@ -3527,7 +3528,7 @@ keycmd_t keycmds_game[] =
 	{"+jump", 			"Jump / Swim up"},
 	{"+strafe", 		"Strafe"},
 	{"centerview", 		"Center view"},
-	{"+mlook", 			"Mouse look"},
+	{"+mlook", 			"Mouselook on/off"},
 	{"+moveup",			"Swim up"},
 	{"+movedown",		"Swim down"},
 	{"+left", 			"Turn left"},

--- a/vid_glx.c
+++ b/vid_glx.c
@@ -1299,15 +1299,15 @@ void IN_MouseMove (usercmd_t *cmd)
 	mouse_y *= sensitivity.value;
 
 	// add mouse X/Y movement to cmd
-	if ((in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1)))
+	if ((in_strafe.state & 1) || (lookstrafe.value && mouselook))
 		cmd->sidemove += m_side.value * mouse_x;
 	else
 		cl.viewangles[YAW] -= m_yaw.value * mouse_x;
 
-	if (in_mlook.state & 1)
+	if (mouselook)
 		V_StopPitchDrift ();
 
-	if ((in_mlook.state & 1) && !(in_strafe.state & 1))
+	if (mouselook && !(in_strafe.state & 1))
 	{
 		cl.viewangles[PITCH] += m_pitch.value * mouse_y;
 		cl.viewangles[PITCH] = bound(-70, cl.viewangles[PITCH], 80);


### PR DESCRIPTION
Resolves issue #55.

This adds the archived cvar m_look, exposed in the menu as "always mouselook".

m_look 1 is the default. When m_look is 1, vertical mouselook is always
enabled, and the +mlook state is irrelevant.

m_look 0 behaves like original Quake, where +mlook must be active in order to
have vertical mouselook.
